### PR TITLE
Camera Fix

### DIFF
--- a/German/main/MiuiCamera.apk/res/values-de/strings.xml
+++ b/German/main/MiuiCamera.apk/res/values-de/strings.xml
@@ -246,9 +246,6 @@
   <string name="pref_camera_snap_entry_off">Aus</string>
   <string name="pref_camera_snap_entry_take_movie">Wenn das Display ausgeschaltet ist, drücken und halten Sie die Leiser-Taste, um die Aufnahme zu starten. Loslassen, um zu stoppen.</string>
   <string name="pref_camera_snap_entry_take_picture">Wenn das Display ausgeschaltet ist, drücken und halten Sie die Leiser-Taste, um die Serienaufnahme zu starten. Loslassen, um zu stoppen.</string>
-  <string name="pref_camera_snap_value_off">Aus</string>
-  <string name="pref_camera_snap_value_take_movie">Viedo</string>
-  <string name="pref_camera_snap_value_take_picture">Foto</string>
   <string name="pref_camera_sound_title">Kameratöne</string>
   <string name="pref_camera_tilt_shift_title">Tilt-Shift</string>
   <string name="pref_camera_touchafaec_entry_off">Aus</string>


### PR DESCRIPTION
"value strings" normaleweise darf man nicht überzetzen