### PR TITLE
XML 6.1.21 (übersetzt)

### DIFF
--- a/German/main/Shell.apk/res/values-de/strings.xml
+++ b/German/main/Shell.apk/res/values-de/strings.xml
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <resources>
   <string name="app_label">Shell</string>
-  <string name="bugreport_confirm">"Bug reports contain data from the system's various log files, including personal and private information. Only share bug reports with apps and people you trust."</string>
-  <string name="bugreport_confirm_repeat">Show this message next time</string>
-  <string name="bugreport_finished_text">Touch to share your bug report</string>
+  <string name="bugreport_confirm">"Programmfehler-Berichte enthalten Daten von den verschiedenen Protokolldateien des Systems einschließlich der persönlichen und privaten Information. Teilen Sie nur Programmfehler-Berichte mit apps und Leuten, denen Sie vertrauen."</string>
+  <string name="bugreport_confirm_repeat">Zeigen Sie dieser Nachricht nächstes Mal</string>
+  <string name="bugreport_finished_text">Berühren Sie, um Ihr Fehlerbericht zu teilen</string>
   <string name="bugreport_finished_title">Bug report captured</string>
   <string name="bugreport_storage_title">Bug reports</string>
 </resources>


### PR DESCRIPTION
Bug report captured = CAPTURED bedeutet = (gefangen , eingefangen, erbeutet, gekapert) keine ahnung welche wörter wir benutzen sollen.